### PR TITLE
Better rotation when rotating upside down viewport

### DIFF
--- a/src/com/mrcrayfish/modelcreator/Camera.java
+++ b/src/com/mrcrayfish/modelcreator/Camera.java
@@ -145,11 +145,11 @@ public class Camera
 
 	public void rotateX(float amt)
 	{
-		rx += amt;
+		rx = ((rx + amt) % 360);
 	}
 
 	public void rotateY(float amt)
 	{
-		ry += amt;
+		ry = ((ry + amt) % 360);
 	}
 }

--- a/src/com/mrcrayfish/modelcreator/ModelCreator.java
+++ b/src/com/mrcrayfish/modelcreator/ModelCreator.java
@@ -253,8 +253,10 @@ public class ModelCreator extends JFrame
 		}
 		else if (Mouse.isButtonDown(1))
 		{
-			camera.rotateY((float) Mouse.getDX() * 0.5F);
 			camera.rotateX(-(float) Mouse.getDY() * 0.5F);
+
+			final float rxAbs = Math.abs(camera.getRX());
+			camera.rotateY((rxAbs >= 90 && rxAbs < 270 ? -1 : 1) * (float) Mouse.getDX() * 0.5F);
 		}
 
 		camera.addZ((float) Mouse.getDWheel() / 100F);


### PR DESCRIPTION
This fixes the inverted rotation movement when the viewport is upside down (rotating to the right would rotate to the left), which is physically correct, but weird when dealing inside an editor.

This also fixes rotations exceeding their logical limits (360 for X, fullcircle, and 180 for Y, half a circle).