### PR TITLE
Fixed weird cuboid offset positions

### DIFF
--- a/src/com/mrcrayfish/modelcreator/Camera.java
+++ b/src/com/mrcrayfish/modelcreator/Camera.java
@@ -31,10 +31,10 @@ public class Camera
 	public Camera(float fov, float aspect, float near, float far)
 	{
 		x = 0;
-		y = 0;
-		z = -5;
-		rx = 45F;
-		ry = 0;
+		y = -2;
+		z = -32;
+		rx = 22.1F;
+		ry = 45F;
 		rz = 0;
 
 		this.fov = fov;
@@ -60,6 +60,7 @@ public class Camera
 		glRotatef(rx, 1, 0, 0);
 		glRotatef(ry, 0, 1, 0);
 		glRotatef(rz, 0, 0, 1);
+		glTranslatef(-8, 0, -8);
 	}
 
 	public float getX()

--- a/src/com/mrcrayfish/modelcreator/Cuboid.java
+++ b/src/com/mrcrayfish/modelcreator/Cuboid.java
@@ -20,7 +20,7 @@ public class Cuboid
 	private double width = 1.0, height = 1.0, depth = 1.0;
 
 	// Rotation Variables
-	private double originX = 8, originY = 8, originZ = 8;
+	private double originX = 0, originY = 0, originZ = 0;
 	private double rotation;
 	private int axis = 0;
 	private boolean rescale = false;
@@ -150,38 +150,38 @@ public class Cuboid
 		{
 			GL11.glEnable(GL_TEXTURE_2D);
 			GL11.glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-			GL11.glTranslated(getOriginX(), getOriginY(), -getOriginZ());
+			GL11.glTranslated(getOriginX(), getOriginY(), getOriginZ());
 			rotateAxis();
-			GL11.glTranslated(-getOriginX(), -getOriginY(), getOriginZ());
+			GL11.glTranslated(-getOriginX(), -getOriginY(), -getOriginZ());
 			if (faces[0].isEnabled())
 			{
 				GL11.glColor3f(1, 0, 0);
-				faces[0].render(startX, startY, -startZ, startX + width, startY + height, -startZ, width, height);
+				faces[0].render(startX, startY, startZ, startX + width, startY + height, startZ, width, height);
 			}
 			if (faces[1].isEnabled())
 			{
 				GL11.glColor3f(0, 1, 0);
-				faces[1].render(startX, startY, -(startZ + depth), startX + width, startY + height, -(startZ + depth), width, height);
+				faces[1].render(startX, startY, (startZ + depth), startX + width, startY + height, (startZ + depth), width, height);
 			}
 			if (faces[2].isEnabled())
 			{
 				GL11.glColor3f(0, 0, 1);
-				faces[2].render(startX, startY, -startZ, startX, startY + height, -(startZ + depth), depth, height);
+				faces[2].render(startX, startY, startZ, startX, startY + height, (startZ + depth), depth, height);
 			}
 			if (faces[3].isEnabled())
 			{
 				GL11.glColor3f(1, 1, 0);
-				faces[3].render(startX + width, startY, -startZ, startX + width, startY + height, -(startZ + depth), depth, height);
+				faces[3].render(startX + width, startY, startZ, startX + width, startY + height, (startZ + depth), depth, height);
 			}
 			if (faces[4].isEnabled())
 			{
 				GL11.glColor3f(1, 0, 1);
-				faces[4].render(startX, startY, -startZ, startX + width, startY, -(startZ + depth), width, depth);
+				faces[4].render(startX, startY, startZ, startX + width, startY, (startZ + depth), width, depth);
 			}
 			if (faces[5].isEnabled())
 			{
 				GL11.glColor3f(0, 1, 1);
-				faces[5].render(startX, startY + height, -startZ, startX + width, startY + height, -(startZ + depth), width, depth);
+				faces[5].render(startX, startY + height, startZ, startX + width, startY + height, (startZ + depth), width, depth);
 			}
 			GL11.glDisable(GL_TEXTURE_2D);
 		}
@@ -192,7 +192,7 @@ public class Cuboid
 	{
 		GL11.glPushMatrix();
 		{
-			GL11.glTranslated(getOriginX(), getOriginY(), -getOriginZ());
+			GL11.glTranslated(getOriginX(), getOriginY(), getOriginZ());
 			sphere.draw(0.2F, 16, 16);
 		}
 		GL11.glPopMatrix();

--- a/src/com/mrcrayfish/modelcreator/ModelCreator.java
+++ b/src/com/mrcrayfish/modelcreator/ModelCreator.java
@@ -227,11 +227,9 @@ public class ModelCreator extends JFrame
 			camera.useView();
 
 			glClearColor(0.92F, 0.92F, 0.93F, 1.0F);
-			glScalef(0.25F, 0.25F, 0.25F);
 			drawGrid();
 			drawAxis();
 
-			glTranslatef(-8, 0, 8);
 			for (int i = 0; i < manager.getCuboidCount(); i++)
 			{
 				Cuboid cube = manager.getCuboid(i);
@@ -291,14 +289,14 @@ public class ModelCreator extends JFrame
 			glLineWidth(2F);
 			glBegin(GL_LINES);
 			{
-				glVertex3i(-8, 0, -8);
-				glVertex3i(-8, 0, 8);
-				glVertex3i(8, 0, -8);
-				glVertex3i(8, 0, 8);
-				glVertex3i(-8, 0, 8);
-				glVertex3i(8, 0, 8);
-				glVertex3i(-8, 0, -8);
-				glVertex3i(8, 0, -8);
+				glVertex3i(0, 0, 0);
+				glVertex3i(0, 0, 16);
+				glVertex3i(16, 0, 0);
+				glVertex3i(16, 0, 16);
+				glVertex3i(0, 0, 16);
+				glVertex3i(16, 0, 16);
+				glVertex3i(0, 0, 0);
+				glVertex3i(16, 0, 0);
 			}
 			glEnd();
 
@@ -306,16 +304,16 @@ public class ModelCreator extends JFrame
 			glLineWidth(1F);
 			glBegin(GL_LINES);
 			{
-				for (int i = -7; i <= 7; i++)
+				for (int i = 1; i <= 16; i++)
 				{
-					glVertex3i(i, 0, -8);
-					glVertex3i(i, 0, 8);
+					glVertex3i(i, 0, 0);
+					glVertex3i(i, 0, 16);
 				}
 
-				for (int i = -7; i <= 7; i++)
+				for (int i = 1; i <= 16; i++)
 				{
-					glVertex3i(-8, 0, i);
-					glVertex3i(8, 0, i);
+					glVertex3i(0, 0, i);
+					glVertex3i(16, 0, i);
 				}
 			}
 			glEnd();
@@ -328,19 +326,19 @@ public class ModelCreator extends JFrame
 		glPushMatrix();
 		{
 			GL11.glLineWidth(5F);
-			glTranslatef(-9, 0, -9);
+			glTranslatef(-1, 0, -1);
 			glBegin(GL_LINES);
 			{
-				glColor4f(0, 1, 0, 0.5F);
-				glVertex3f(40F, 0.01F, 0);
+				glColor4f(1, 0, 0, 0.5F);
+				glVertex3f(32F, 0.01F, 0);
 				glVertex3f(0, 0.01F, 0);
 
-				glColor4f(1, 0, 0, 0.5F);
+				glColor4f(0, 1, 0, 0.5F);
 				glVertex3f(0, 0.01F, 0);
-				glVertex3f(0, 40F, 0);
+				glVertex3f(0, 32F, 0);
 
 				glColor4f(0, 0, 1, 0.5F);
-				glVertex3f(0, 0.01F, 40F);
+				glVertex3f(0, 0.01F, 32F);
 				glVertex3f(0, 0.01F, 0);
 			}
 			glEnd();


### PR DESCRIPTION
This basically cleans up the translating, rotating and scaling to make much more sense when we're working with blocks as units.

Before we had a scale of 25%, so a block would be 0.5 wide in terms of GL space. This has been fixed as we no longer do any additional translating or scaling.

Additionally the camera has been set to a much nicer starting position in which we see that the viewport can indeed be rotated (before we had only a 45° downwards rotation).