### PR TITLE
Add auto uv checkbox

### DIFF
--- a/src/com/mrcrayfish/modelcreator/Importer.java
+++ b/src/com/mrcrayfish/modelcreator/Importer.java
@@ -162,6 +162,7 @@ public class Importer
 			
 			for(Face face : element.getAllFaces()) {
 				face.setEnabled(false);
+				face.setAutoUVEnabled(false);
 			}
 			
 			if(obj.has("faces") && obj.get("faces").isJsonObject()) {

--- a/src/com/mrcrayfish/modelcreator/element/Element.java
+++ b/src/com/mrcrayfish/modelcreator/element/Element.java
@@ -401,6 +401,12 @@ public class Element
 	{
 		return name;
 	}
+	
+	public void updateUV() {
+		for(Face face : faces) {
+			face.updateUV();
+		}
+	}
 
 	public void rotateAxis()
 	{

--- a/src/com/mrcrayfish/modelcreator/element/Element.java
+++ b/src/com/mrcrayfish/modelcreator/element/Element.java
@@ -63,11 +63,15 @@ public class Element
 			faces[i].fitTexture(oldFace.shouldFitTexture());
 			faces[i].setTexture(oldFace.getTextureName());
 			faces[i].setTextureLocation(oldFace.getTextureLocation());
-			faces[i].addTextureX(oldFace.getStartU());
-			faces[i].addTextureY(oldFace.getStartV());
+			faces[i].setStartU(oldFace.getStartU());
+			faces[i].setStartV(oldFace.getStartV());
+			faces[i].setEndU(oldFace.getEndU());
+			faces[i].setEndV(oldFace.getEndV());
 			faces[i].setCullface(oldFace.isCullfaced());
 			faces[i].setEnabled(oldFace.isEnabled());
+			faces[i].setAutoUVEnabled(oldFace.isAutoUVEnabled());
 		}
+		updateUV();
 	}
 
 	public void initFaces()

--- a/src/com/mrcrayfish/modelcreator/element/Face.java
+++ b/src/com/mrcrayfish/modelcreator/element/Face.java
@@ -22,6 +22,7 @@ public class Face
 	private boolean binded = false;
 	private boolean cullface = false;
 	private boolean enabled = true;
+	private boolean autoUV = true;
 	private double rotation;
 
 	private Element cuboid;
@@ -361,6 +362,23 @@ public class Face
 	public void setEnabled(boolean enabled)
 	{
 		this.enabled = enabled;
+	}
+	
+	public boolean isAutoUVEnabled()
+	{
+		return autoUV;
+	}
+
+	public void setAutoUVEnabled(boolean enabled)
+	{
+		this.autoUV = enabled;
+	}
+	
+	public void updateUV() {
+		if(autoUV) {
+			textureUEnd = textureU + cuboid.getFaceDimension(side).getWidth();
+			textureVEnd = textureV + cuboid.getFaceDimension(side).getHeight();
+		}
 	}
 
 	public static String getFaceName(int face)

--- a/src/com/mrcrayfish/modelcreator/panels/FaceExtrasPanel.java
+++ b/src/com/mrcrayfish/modelcreator/panels/FaceExtrasPanel.java
@@ -21,6 +21,7 @@ public class FaceExtrasPanel extends JPanel implements IValueUpdater
 	private JRadioButton boxCullFace;
 	private JRadioButton boxFill;
 	private JRadioButton boxEnabled;
+	private JRadioButton boxAutoUV;
 
 	public FaceExtrasPanel(ElementManager manager)
 	{
@@ -53,10 +54,18 @@ public class FaceExtrasPanel extends JPanel implements IValueUpdater
 		{
 			manager.getSelectedCuboid().getSelectedFace().setEnabled(boxEnabled.isSelected());
 		});
+		boxAutoUV = new JRadioButton("Auto UV");
+		boxAutoUV.setToolTipText("<html>Determines if uv end coordinates should be set based on element size<br>Default: On</html>");
+		boxAutoUV.addActionListener(e ->
+		{
+			manager.getSelectedCuboid().getSelectedFace().setAutoUVEnabled(boxAutoUV.isSelected());
+			manager.getSelectedCuboid().getSelectedFace().updateUV();
+			manager.updateValues();
+		});
 		horizontalBox.add(boxCullFace);
 		horizontalBox.add(boxFill);
 		horizontalBox.add(boxEnabled);
-
+		horizontalBox.add(boxAutoUV);
 		
 	}
 
@@ -76,6 +85,8 @@ public class FaceExtrasPanel extends JPanel implements IValueUpdater
 			boxFill.setSelected(cube.getSelectedFace().shouldFitTexture());
 			boxEnabled.setEnabled(true);
 			boxEnabled.setSelected(cube.getSelectedFace().isEnabled());
+			boxAutoUV.setEnabled(true);
+			boxAutoUV.setSelected(cube.getSelectedFace().isAutoUVEnabled());
 		}
 		else
 		{
@@ -85,6 +96,8 @@ public class FaceExtrasPanel extends JPanel implements IValueUpdater
 			boxFill.setSelected(false);
 			boxEnabled.setEnabled(false);
 			boxEnabled.setSelected(false);
+			boxAutoUV.setEnabled(false);
+			boxAutoUV.setSelected(false);
 		}
 	}
 }

--- a/src/com/mrcrayfish/modelcreator/panels/SizePanel.java
+++ b/src/com/mrcrayfish/modelcreator/panels/SizePanel.java
@@ -87,7 +87,8 @@ public class SizePanel extends JPanel implements IValueUpdater
 				{
 					cube.addWidth(1.0F);
 				}
-				xSizeField.setText(df.format(cube.getWidth()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnPlusX.setPreferredSize(new Dimension(62, 30));
@@ -106,7 +107,8 @@ public class SizePanel extends JPanel implements IValueUpdater
 				{
 					cube.addHeight(1.0F);
 				}
-				ySizeField.setText(df.format(cube.getHeight()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnPlusY.setPreferredSize(new Dimension(62, 30));
@@ -125,7 +127,8 @@ public class SizePanel extends JPanel implements IValueUpdater
 				{
 					cube.addDepth(1.0F);
 				}
-				zSizeField.setText(df.format(cube.getDepth()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnPlusZ.setPreferredSize(new Dimension(62, 30));
@@ -144,7 +147,8 @@ public class SizePanel extends JPanel implements IValueUpdater
 				{
 					cube.addWidth(-1.0F);
 				}
-				xSizeField.setText(df.format(cube.getWidth()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnNegX.setPreferredSize(new Dimension(62, 30));
@@ -163,7 +167,8 @@ public class SizePanel extends JPanel implements IValueUpdater
 				{
 					cube.addHeight(-1.0F);
 				}
-				ySizeField.setText(df.format(cube.getHeight()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnNegY.setPreferredSize(new Dimension(62, 30));
@@ -182,7 +187,8 @@ public class SizePanel extends JPanel implements IValueUpdater
 				{
 					cube.addDepth(-1.0F);
 				}
-				zSizeField.setText(df.format(cube.getDepth()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnNegZ.setPreferredSize(new Dimension(62, 30));

--- a/src/com/mrcrayfish/modelcreator/panels/UVPanel.java
+++ b/src/com/mrcrayfish/modelcreator/panels/UVPanel.java
@@ -39,7 +39,7 @@ public class UVPanel extends JPanel implements IValueUpdater
 	public UVPanel(ElementManager manager)
 	{
 		this.manager = manager;
-		setLayout(new GridLayout(3, 3, 4, 4));
+		setLayout(new GridLayout(3, 4, 4, 4));
 		setBorder(BorderFactory.createTitledBorder(BorderFactory.createEmptyBorder(), "UV"));
 		setMaximumSize(new Dimension(186, 124));
 		initComponents();
@@ -101,7 +101,8 @@ public class UVPanel extends JPanel implements IValueUpdater
 				{
 					face.addTextureX(1.0);
 				}
-				xStartField.setText(df.format(face.getStartU()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnPlusX.setSize(new Dimension(62, 30));
@@ -121,7 +122,8 @@ public class UVPanel extends JPanel implements IValueUpdater
 				{
 					face.addTextureY(1.0);
 				}
-				yStartField.setText(df.format(face.getStartV()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnPlusY.setPreferredSize(new Dimension(62, 30));
@@ -141,7 +143,8 @@ public class UVPanel extends JPanel implements IValueUpdater
 				{
 					face.addTextureX(-1.0);
 				}
-				xStartField.setText(df.format(face.getStartU()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnNegX.setSize(new Dimension(62, 30));
@@ -161,7 +164,8 @@ public class UVPanel extends JPanel implements IValueUpdater
 				{
 					face.addTextureY(-1.0);
 				}
-				yStartField.setText(df.format(face.getStartV()));
+				cube.updateUV();
+				manager.updateValues();
 			}
 		});
 		btnNegY.setSize(new Dimension(62, 30));
@@ -181,7 +185,8 @@ public class UVPanel extends JPanel implements IValueUpdater
 				{
 					face.addTextureXEnd(1.0);
 				}
-				xEndField.setText(df.format(face.getEndU()));
+				face.setAutoUVEnabled(false);
+				manager.updateValues();
 			}
 		});
 		btnPlusXEnd.setSize(new Dimension(62, 30));
@@ -201,7 +206,8 @@ public class UVPanel extends JPanel implements IValueUpdater
 				{
 					face.addTextureYEnd(1.0);
 				}
-				yEndField.setText(df.format(face.getEndV()));
+				face.setAutoUVEnabled(false);
+				manager.updateValues();
 			}
 		});
 		btnPlusYEnd.setPreferredSize(new Dimension(62, 30));
@@ -221,7 +227,8 @@ public class UVPanel extends JPanel implements IValueUpdater
 				{
 					face.addTextureXEnd(-1.0);
 				}
-				xEndField.setText(df.format(face.getEndU()));
+				face.setAutoUVEnabled(false);
+				manager.updateValues();
 			}
 		});
 		btnNegXEnd.setSize(new Dimension(62, 30));
@@ -241,7 +248,8 @@ public class UVPanel extends JPanel implements IValueUpdater
 				{
 					face.addTextureYEnd(-1.0);
 				}
-				yEndField.setText(df.format(face.getEndV()));
+				face.setAutoUVEnabled(false);
+				manager.updateValues();
 			}
 		});
 		btnNegYEnd.setSize(new Dimension(62, 30));

--- a/src/com/mrcrayfish/modelcreator/panels/tabs/FacePanel.java
+++ b/src/com/mrcrayfish/modelcreator/panels/tabs/FacePanel.java
@@ -15,6 +15,7 @@ import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import javax.swing.JSlider;
 import javax.swing.JTextField;
 
@@ -34,6 +35,7 @@ public class FacePanel extends JPanel implements IValueUpdater
 	private JPanel menuPanel;
 	private JComboBox<String> menuList;
 	private UVPanel panelUV;
+	private JRadioButton boxAutoUV;
 	private JPanel sliderPanel;
 	private JSlider rotation;
 	private TexturePanel panelTexture;
@@ -88,6 +90,15 @@ public class FacePanel extends JPanel implements IValueUpdater
 		panelTexture = new TexturePanel(manager);
 		panelUV = new UVPanel(manager);
 		panelProperties = new FaceExtrasPanel(manager);
+		
+		boxAutoUV = new JRadioButton("Auto UV");
+		boxAutoUV.setToolTipText("<html>Determines if uv end coordinates should be set based on element size<br>Default: On</html>");
+		boxAutoUV.addActionListener(e ->
+		{
+			manager.getSelectedCuboid().getSelectedFace().setAutoUVEnabled(boxAutoUV.isSelected());
+			manager.getSelectedCuboid().getSelectedFace().updateUV();
+			manager.updateValues();
+		});
 
 		Hashtable<Integer, JLabel> labelTable = new Hashtable<Integer, JLabel>();
 		labelTable.put(new Integer(0), new JLabel("0\u00b0"));
@@ -153,6 +164,8 @@ public class FacePanel extends JPanel implements IValueUpdater
 		add(Box.createRigidArea(new Dimension(192, 5)));
 		add(panelUV);
 		add(Box.createRigidArea(new Dimension(192, 5)));
+		add(boxAutoUV);
+		add(Box.createRigidArea(new Dimension(192, 5)));
 		add(sliderPanel);
 		add(Box.createRigidArea(new Dimension(192, 5)));
 		add(panelModId);
@@ -168,11 +181,14 @@ public class FacePanel extends JPanel implements IValueUpdater
 			menuList.setSelectedIndex(cube.getSelectedFaceIndex());
 			modidField.setEnabled(true);
 			modidField.setText(cube.getSelectedFace().getTextureLocation());
+			boxAutoUV.setEnabled(true);
+			boxAutoUV.setSelected(manager.getSelectedCuboid().getSelectedFace().isAutoUVEnabled());
 		}
 		else
 		{
 			modidField.setEnabled(false);
 			modidField.setText("");
+			boxAutoUV.setEnabled(false);
 		}
 		panelUV.updateValues(cube);
 		panelProperties.updateValues(cube);

--- a/src/com/mrcrayfish/modelcreator/panels/tabs/FacePanel.java
+++ b/src/com/mrcrayfish/modelcreator/panels/tabs/FacePanel.java
@@ -15,7 +15,6 @@ import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import javax.swing.JSlider;
 import javax.swing.JTextField;
 
@@ -35,7 +34,6 @@ public class FacePanel extends JPanel implements IValueUpdater
 	private JPanel menuPanel;
 	private JComboBox<String> menuList;
 	private UVPanel panelUV;
-	private JRadioButton boxAutoUV;
 	private JPanel sliderPanel;
 	private JSlider rotation;
 	private TexturePanel panelTexture;
@@ -90,15 +88,6 @@ public class FacePanel extends JPanel implements IValueUpdater
 		panelTexture = new TexturePanel(manager);
 		panelUV = new UVPanel(manager);
 		panelProperties = new FaceExtrasPanel(manager);
-		
-		boxAutoUV = new JRadioButton("Auto UV");
-		boxAutoUV.setToolTipText("<html>Determines if uv end coordinates should be set based on element size<br>Default: On</html>");
-		boxAutoUV.addActionListener(e ->
-		{
-			manager.getSelectedCuboid().getSelectedFace().setAutoUVEnabled(boxAutoUV.isSelected());
-			manager.getSelectedCuboid().getSelectedFace().updateUV();
-			manager.updateValues();
-		});
 
 		Hashtable<Integer, JLabel> labelTable = new Hashtable<Integer, JLabel>();
 		labelTable.put(new Integer(0), new JLabel("0\u00b0"));
@@ -164,8 +153,6 @@ public class FacePanel extends JPanel implements IValueUpdater
 		add(Box.createRigidArea(new Dimension(192, 5)));
 		add(panelUV);
 		add(Box.createRigidArea(new Dimension(192, 5)));
-		add(boxAutoUV);
-		add(Box.createRigidArea(new Dimension(192, 5)));
 		add(sliderPanel);
 		add(Box.createRigidArea(new Dimension(192, 5)));
 		add(panelModId);
@@ -181,14 +168,11 @@ public class FacePanel extends JPanel implements IValueUpdater
 			menuList.setSelectedIndex(cube.getSelectedFaceIndex());
 			modidField.setEnabled(true);
 			modidField.setText(cube.getSelectedFace().getTextureLocation());
-			boxAutoUV.setEnabled(true);
-			boxAutoUV.setSelected(manager.getSelectedCuboid().getSelectedFace().isAutoUVEnabled());
 		}
 		else
 		{
 			modidField.setEnabled(false);
 			modidField.setText("");
-			boxAutoUV.setEnabled(false);
 		}
 		panelUV.updateValues(cube);
 		panelProperties.updateValues(cube);


### PR DESCRIPTION
Adds back the old behaviour of automatically setting the UV end coordinates but with the option to disable it.

Disabled for imported models by default 