### PR TITLE
Fix for loading cached texture.

### DIFF
--- a/src/com/mrcrayfish/modelcreator/texture/PendingTexture.java
+++ b/src/com/mrcrayfish/modelcreator/texture/PendingTexture.java
@@ -50,6 +50,11 @@ public class PendingTexture
 				result = TextureManager.loadExternalTexture(this.texture, this.meta);
 				is.close();
 			}
+			else
+			{
+				result = true;
+			}
+
 			if (callback != null)
 				callback.callback(result, fileName);
 		}


### PR DESCRIPTION
Hello MrCrayfish!

I found that if I am loading an already loaded texture, it will fail the second time.
It seems like it is because `result` will not become true.

best regards
/Anders