### PR TITLE
Remembering directories across runs

### DIFF
--- a/src/com/mrcrayfish/modelcreator/Menu.java
+++ b/src/com/mrcrayfish/modelcreator/Menu.java
@@ -336,6 +336,13 @@ public class Menu extends JMenuBar
 			FileNameExtensionFilter filter = new FileNameExtensionFilter("PNG (.png)", "png");
 			chooser.setFileFilter(filter);
 
+			String dir = Settings.getScreenshotDir();
+			
+			if (dir != null)
+			{
+				chooser.setCurrentDirectory(new File(dir));
+			}
+
 			int returnVal = chooser.showOpenDialog(null);
 			if (returnVal == JFileChooser.APPROVE_OPTION)
 			{
@@ -345,6 +352,9 @@ public class Menu extends JMenuBar
 				}
 				if (returnVal != JOptionPane.NO_OPTION && returnVal != JOptionPane.CLOSED_OPTION)
 				{
+					File location = chooser.getSelectedFile().getParentFile();
+					Settings.setScreenshotDir(location.toString());
+
 					String filePath = chooser.getSelectedFile().getAbsolutePath();
 					if (!filePath.endsWith(".png"))
 						chooser.setSelectedFile(new File(filePath + ".png"));

--- a/src/com/mrcrayfish/modelcreator/Menu.java
+++ b/src/com/mrcrayfish/modelcreator/Menu.java
@@ -168,6 +168,13 @@ public class Menu extends JMenuBar
 			FileNameExtensionFilter filter = new FileNameExtensionFilter("Model (.model)", "model");
 			chooser.setFileFilter(filter);
 
+			String dir = Settings.getModelDir();
+			
+			if (dir != null)
+			{
+				chooser.setCurrentDirectory(new File(dir));
+			}
+
 			int returnVal = chooser.showOpenDialog(null);
 			if (returnVal == JFileChooser.APPROVE_OPTION)
 			{
@@ -177,6 +184,9 @@ public class Menu extends JMenuBar
 				}
 				if (returnVal != JOptionPane.NO_OPTION && returnVal != JOptionPane.CLOSED_OPTION)
 				{
+					File location = chooser.getSelectedFile().getParentFile();
+					Settings.setModelDir(location.toString());
+
 					ProjectManager.loadProject(creator.getElementManager(), chooser.getSelectedFile().getAbsolutePath());
 				}
 			}
@@ -191,6 +201,12 @@ public class Menu extends JMenuBar
 
 			FileNameExtensionFilter filter = new FileNameExtensionFilter("Model (.model)", "model");
 			chooser.setFileFilter(filter);
+			String dir = Settings.getModelDir();
+			
+			if (dir != null)
+			{
+				chooser.setCurrentDirectory(new File(dir));
+			}
 
 			int returnVal = chooser.showOpenDialog(null);
 			if (returnVal == JFileChooser.APPROVE_OPTION)
@@ -201,6 +217,9 @@ public class Menu extends JMenuBar
 				}
 				if (returnVal != JOptionPane.NO_OPTION && returnVal != JOptionPane.CLOSED_OPTION)
 				{
+					File location = chooser.getSelectedFile().getParentFile();
+					Settings.setModelDir(location.toString());
+
 					String filePath = chooser.getSelectedFile().getAbsolutePath();
 					if (!filePath.endsWith(".model"))
 						filePath += ".model";

--- a/src/com/mrcrayfish/modelcreator/Menu.java
+++ b/src/com/mrcrayfish/modelcreator/Menu.java
@@ -208,7 +208,7 @@ public class Menu extends JMenuBar
 				chooser.setCurrentDirectory(new File(dir));
 			}
 
-			int returnVal = chooser.showOpenDialog(null);
+			int returnVal = chooser.showSaveDialog(null);
 			if (returnVal == JFileChooser.APPROVE_OPTION)
 			{
 				if (chooser.getSelectedFile().exists())
@@ -281,7 +281,7 @@ public class Menu extends JMenuBar
 				chooser.setCurrentDirectory(new File(dir));
 			}
 
-			int returnVal = chooser.showOpenDialog(null);
+			int returnVal = chooser.showSaveDialog(null);
 			if (returnVal == JFileChooser.APPROVE_OPTION)
 			{
 				if (chooser.getSelectedFile().exists())
@@ -349,7 +349,7 @@ public class Menu extends JMenuBar
 				chooser.setCurrentDirectory(new File(dir));
 			}
 
-			int returnVal = chooser.showOpenDialog(null);
+			int returnVal = chooser.showSaveDialog(null);
 			if (returnVal == JFileChooser.APPROVE_OPTION)
 			{
 				if (chooser.getSelectedFile().exists())

--- a/src/com/mrcrayfish/modelcreator/Menu.java
+++ b/src/com/mrcrayfish/modelcreator/Menu.java
@@ -307,6 +307,12 @@ public class Menu extends JMenuBar
 			JFileChooser chooser = new JFileChooser();
 			chooser.setDialogTitle("Texture Path");
 			chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+
+			if (ModelCreator.texturePath != null)
+			{
+				chooser.setCurrentDirectory(new File(ModelCreator.texturePath));
+			}
+
 			int returnVal = chooser.showOpenDialog(null);
 			if (returnVal == JFileChooser.APPROVE_OPTION)
 			{

--- a/src/com/mrcrayfish/modelcreator/Menu.java
+++ b/src/com/mrcrayfish/modelcreator/Menu.java
@@ -219,6 +219,13 @@ public class Menu extends JMenuBar
 			FileNameExtensionFilter filter = new FileNameExtensionFilter("JSON (.json)", "json");
 			chooser.setFileFilter(filter);
 
+			String dir = Settings.getJSONDir();
+			
+			if (dir != null)
+			{
+				chooser.setCurrentDirectory(new File(dir));
+			}
+
 			int returnVal = chooser.showOpenDialog(null);
 			if (returnVal == JFileChooser.APPROVE_OPTION)
 			{
@@ -228,6 +235,9 @@ public class Menu extends JMenuBar
 				}
 				if (returnVal != JOptionPane.NO_OPTION && returnVal != JOptionPane.CLOSED_OPTION)
 				{
+					File location = chooser.getSelectedFile().getParentFile();
+					Settings.setJSONDir(location.toString());
+
 					Importer importer = new Importer(creator.getElementManager(), chooser.getSelectedFile().getAbsolutePath());
 					importer.importFromJSON();
 				}
@@ -245,6 +255,13 @@ public class Menu extends JMenuBar
 			FileNameExtensionFilter filter = new FileNameExtensionFilter("JSON (.json)", "json");
 			chooser.setFileFilter(filter);
 
+			String dir = Settings.getJSONDir();
+			
+			if (dir != null)
+			{
+				chooser.setCurrentDirectory(new File(dir));
+			}
+
 			int returnVal = chooser.showOpenDialog(null);
 			if (returnVal == JFileChooser.APPROVE_OPTION)
 			{
@@ -254,6 +271,9 @@ public class Menu extends JMenuBar
 				}
 				if (returnVal != JOptionPane.NO_OPTION && returnVal != JOptionPane.CLOSED_OPTION)
 				{
+					File location = chooser.getSelectedFile().getParentFile();
+					Settings.setJSONDir(location.toString());
+
 					String filePath = chooser.getSelectedFile().getAbsolutePath();
 					if (!filePath.endsWith(".json"))
 						chooser.setSelectedFile(new File(filePath + ".json"));

--- a/src/com/mrcrayfish/modelcreator/Settings.java
+++ b/src/com/mrcrayfish/modelcreator/Settings.java
@@ -5,6 +5,7 @@ import java.util.prefs.Preferences;
 public class Settings
 {
 	private static final String IMAGE_IMPORT_DIR = "imageimportdir";
+	private static final String JSON_DIR = "jsondir";
 
 	public static String getImageImportDir()
 	{
@@ -16,5 +17,22 @@ public class Settings
 	{		
 		Preferences prefs = getPreferences();
 		prefs.put(IMAGE_IMPORT_DIR, dir);
+	}
+
+	public static String getJSONDir()
+	{
+		Preferences prefs = getPreferences();
+		return prefs.get(JSON_DIR, null);
+	}
+	
+	public static void setJSONDir(String dir)
+	{		
+		Preferences prefs = getPreferences();
+		prefs.put(JSON_DIR, dir);
+	}		
+	
+	private static Preferences getPreferences()
+	{
+		return Preferences.userNodeForPackage(Settings.class);
 	}
 }

--- a/src/com/mrcrayfish/modelcreator/Settings.java
+++ b/src/com/mrcrayfish/modelcreator/Settings.java
@@ -1,0 +1,20 @@
+package com.mrcrayfish.modelcreator;
+
+import java.util.prefs.Preferences;
+
+public class Settings
+{
+	private static final String IMAGE_IMPORT_DIR = "imageimportdir";
+
+	public static String getImageImportDir()
+	{
+		Preferences prefs = getPreferences();
+		return prefs.get(IMAGE_IMPORT_DIR, null);
+	}
+	
+	public static void setImageImportDir(String dir)
+	{		
+		Preferences prefs = getPreferences();
+		prefs.put(IMAGE_IMPORT_DIR, dir);
+	}
+}

--- a/src/com/mrcrayfish/modelcreator/Settings.java
+++ b/src/com/mrcrayfish/modelcreator/Settings.java
@@ -5,6 +5,7 @@ import java.util.prefs.Preferences;
 public class Settings
 {
 	private static final String IMAGE_IMPORT_DIR = "imageimportdir";
+	private static final String MODEL_DIR = "modeldir";
 	private static final String JSON_DIR = "jsondir";
 
 	public static String getImageImportDir()
@@ -18,6 +19,18 @@ public class Settings
 		Preferences prefs = getPreferences();
 		prefs.put(IMAGE_IMPORT_DIR, dir);
 	}
+
+	public static String getModelDir()
+	{
+		Preferences prefs = getPreferences();
+		return prefs.get(MODEL_DIR, null);
+	}
+	
+	public static void setModelDir(String dir)
+	{		
+		Preferences prefs = getPreferences();
+		prefs.put(MODEL_DIR, dir);
+	}		
 
 	public static String getJSONDir()
 	{

--- a/src/com/mrcrayfish/modelcreator/Settings.java
+++ b/src/com/mrcrayfish/modelcreator/Settings.java
@@ -5,6 +5,7 @@ import java.util.prefs.Preferences;
 public class Settings
 {
 	private static final String IMAGE_IMPORT_DIR = "imageimportdir";
+	private static final String SCREENSHOT_DIR = "screenshotdir";
 	private static final String MODEL_DIR = "modeldir";
 	private static final String JSON_DIR = "jsondir";
 
@@ -20,6 +21,18 @@ public class Settings
 		prefs.put(IMAGE_IMPORT_DIR, dir);
 	}
 
+	public static String getScreenshotDir()
+	{
+		Preferences prefs = getPreferences();
+		return prefs.get(SCREENSHOT_DIR, null);
+	}
+	
+	public static void setScreenshotDir(String dir)
+	{		
+		Preferences prefs = getPreferences();
+		prefs.put(SCREENSHOT_DIR, dir);
+	}
+	
 	public static String getModelDir()
 	{
 		Preferences prefs = getPreferences();

--- a/src/com/mrcrayfish/modelcreator/texture/TextureManager.java
+++ b/src/com/mrcrayfish/modelcreator/texture/TextureManager.java
@@ -1,6 +1,7 @@
 package com.mrcrayfish.modelcreator.texture;
 
 import com.mrcrayfish.modelcreator.ModelCreator;
+import com.mrcrayfish.modelcreator.Settings;
 import com.mrcrayfish.modelcreator.element.ElementManager;
 import com.mrcrayfish.modelcreator.panels.SidebarPanel;
 import org.newdawn.slick.opengl.Texture;
@@ -192,6 +193,17 @@ public class TextureManager
 		btnImport.addActionListener(a ->
 		{
 			JFileChooser chooser = new JFileChooser();
+			chooser.setDialogTitle("Input File");
+			chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+			chooser.setApproveButtonText("Import");
+			
+			if (lastLocation == null) {
+				String dir = Settings.getImageImportDir();
+
+				if (dir != null)
+					lastLocation = new File(dir);
+			}
+			
 			if (lastLocation != null) {
 				chooser.setCurrentDirectory(lastLocation);
 			}
@@ -213,6 +225,8 @@ public class TextureManager
 			if (returnVal == JFileChooser.APPROVE_OPTION)
 			{
 				lastLocation = chooser.getSelectedFile().getParentFile();
+				Settings.setImageImportDir(lastLocation.toString());
+				
 				try
 				{
 					File meta = new File(chooser.getSelectedFile().getAbsolutePath() + ".mcmeta");


### PR DESCRIPTION
Hello MrCrayFish.

Theese changes lets the application remember some directories so they will be selected in file choosers. Even if you close the program and start it, they will be remembered.

I have only tested this on windows and I can see that the settings are saved in the registry.
Java will use corresponding ways of storing settings in other OS:es, ways I am not fully aware of.

The changes seems to solve the issue https://github.com/MrCrayfish/ModelCreator/issues/44.

json, model, screenshot and image import directories are remembered separately.

Also, the texture directory chooser will be opened in the currently choosen directory.

Save dialogs will be used instead of open dialog in case of saving.

I hope any or all of theese could be useful!
