### PR TITLE
Copy face rotation when duplicating cube

### DIFF
--- a/src/com/mrcrayfish/modelcreator/element/Element.java
+++ b/src/com/mrcrayfish/modelcreator/element/Element.java
@@ -68,6 +68,7 @@ public class Element
 			faces[i].setStartV(oldFace.getStartV());
 			faces[i].setEndU(oldFace.getEndU());
 			faces[i].setEndV(oldFace.getEndV());
+			faces[i].setRotation(oldFace.getRotation());
 			faces[i].setCullface(oldFace.isCullfaced());
 			faces[i].setEnabled(oldFace.isEnabled());
 			faces[i].setAutoUVEnabled(oldFace.isAutoUVEnabled());


### PR DESCRIPTION
This will fix https://github.com/MrCrayfish/ModelCreator/issues/38.
A simple line is added in constructor of `Element` to also copy rotation of faces.