### PR TITLE
When importing json file or loading model, let every face be enabled.

### DIFF
--- a/src/com/mrcrayfish/modelcreator/Importer.java
+++ b/src/com/mrcrayfish/modelcreator/Importer.java
@@ -263,11 +263,6 @@ public class Importer
 				element.setShade(obj.get("shade").getAsBoolean());
 			}
 
-			for (Face face : element.getAllFaces())
-			{
-				face.setEnabled(false);
-			}
-
 			if (obj.has("faces") && obj.get("faces").isJsonObject())
 			{
 				JsonObject faces = obj.get("faces").getAsJsonObject();
@@ -298,8 +293,6 @@ public class Importer
 
 		if (face != null)
 		{
-			face.setEnabled(true);
-
 			// automatically set uv if not specified
 			face.setEndU(element.getFaceDimension(face.getSide()).getWidth());
 			face.setEndV(element.getFaceDimension(face.getSide()).getHeight());


### PR DESCRIPTION
Hello MrCrayfish!
When I create a cube, I will see it even if I did not choose a texture yet.
If I save the file, either exporting it as json or saving it to the model format and then load it again, the faces without texture will not show any longer so I will see nothing after I have loaded the model.

This is maybe not satisfactory.

The change will enable all faces when loading/importing an object.
I am not totally sure this is appropriate, so you better think about it twice before accepting this PR.
When should loaded faces actually be disabled?