### PR TITLE
Transparency mode as checkbox, also being persistent

### DIFF
--- a/src/com/mrcrayfish/modelcreator/Menu.java
+++ b/src/com/mrcrayfish/modelcreator/Menu.java
@@ -6,6 +6,7 @@ import java.awt.event.KeyEvent;
 import java.io.File;
 
 import javax.swing.Icon;
+import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JMenu;
@@ -80,7 +81,7 @@ public class Menu extends JMenuBar
 
 		menuOptions = new JMenu("Options");
 		{
-			itemTransparency = createItem("Toggle Transparency", "Enables transparent rendering in program", KeyEvent.VK_E, Icons.transparent);
+			itemTransparency = createCheckboxItem("Transparency", "Enables transparent rendering in program", KeyEvent.VK_E, ModelCreator.transparent, Icons.transparent);
 		}
 
 		menuScreenshot = new JMenu("Screenshot");
@@ -327,8 +328,11 @@ public class Menu extends JMenuBar
 		itemTransparency.addActionListener(a ->
 		{
 			ModelCreator.transparent ^= true;
+			Settings.setTransparencyMode(ModelCreator.transparent);
 			if (ModelCreator.transparent)
-				JOptionPane.showMessageDialog(null, "<html>Transparent textures do not represent the same as in Minecraft.<br> " + "It depends if the model you are overwriting, allows transparent<br>" + "textures in the code. Blocks like Grass and Stone don't allow<br>" + "transparency, where as Glass and Cauldron do. Please take this into<br>" + "consideration when designing. Transparency is now turned on.<html>", "Rendering Warning", JOptionPane.INFORMATION_MESSAGE);
+				JOptionPane.showMessageDialog(null, "<html>Enabled transparency mode. Transparent textures do not represent the same as in Minecraft.<br> " + "It depends if the model you are overwriting, allows transparent<br>" + "textures in the code. Blocks like Grass and Stone don't allow<br>" + "transparency, where as Glass and Cauldron do. Please take this into<br>" + "consideration when designing. Transparency is now turned on.<html>", "Rendering Warning", JOptionPane.INFORMATION_MESSAGE);
+			else
+				JOptionPane.showMessageDialog(null, "<html>Disabled transparency mode</html>", "Transparency mode", JOptionPane.INFORMATION_MESSAGE);
 		});
 
 		itemSaveToDisk.addActionListener(a ->
@@ -517,6 +521,16 @@ public class Menu extends JMenuBar
 		item.setToolTipText(tooltip);
 		item.setMnemonic(mnemonic);
 		item.setIcon(icon);
+		return item;
+	}
+
+	private JMenuItem createCheckboxItem(String name, String tooltip, int mnemonic, boolean checked, Icon icon)
+	{
+		JMenuItem item = new JCheckBoxMenuItem(name, checked);
+		item.setToolTipText(tooltip);
+		item.setMnemonic(mnemonic);
+		item.setIcon(icon);
+
 		return item;
 	}
 }

--- a/src/com/mrcrayfish/modelcreator/ModelCreator.java
+++ b/src/com/mrcrayfish/modelcreator/ModelCreator.java
@@ -76,7 +76,7 @@ public class ModelCreator extends JFrame
 
 	// TODO remove static instance
 	public static String texturePath = ".";
-	public static boolean transparent = false;
+	public static boolean transparent = Settings.getTransparencyMode();
 
 	// Canvas Variables
 	private final static AtomicReference<Dimension> newCanvasSize = new AtomicReference<Dimension>();
@@ -705,7 +705,7 @@ public class ModelCreator extends JFrame
 	{
 		return manager;
 	}
-	
+
 	public void close()
 	{
 		this.closeRequested = true;

--- a/src/com/mrcrayfish/modelcreator/Settings.java
+++ b/src/com/mrcrayfish/modelcreator/Settings.java
@@ -8,15 +8,16 @@ public class Settings
 	private static final String SCREENSHOT_DIR = "screenshotdir";
 	private static final String MODEL_DIR = "modeldir";
 	private static final String JSON_DIR = "jsondir";
+	private static final String TRANSPARENCY_MODE = "transparency_mode";
 
 	public static String getImageImportDir()
 	{
 		Preferences prefs = getPreferences();
 		return prefs.get(IMAGE_IMPORT_DIR, null);
 	}
-	
+
 	public static void setImageImportDir(String dir)
-	{		
+	{
 		Preferences prefs = getPreferences();
 		prefs.put(IMAGE_IMPORT_DIR, dir);
 	}
@@ -26,37 +27,49 @@ public class Settings
 		Preferences prefs = getPreferences();
 		return prefs.get(SCREENSHOT_DIR, null);
 	}
-	
+
 	public static void setScreenshotDir(String dir)
-	{		
+	{
 		Preferences prefs = getPreferences();
 		prefs.put(SCREENSHOT_DIR, dir);
 	}
-	
+
 	public static String getModelDir()
 	{
 		Preferences prefs = getPreferences();
 		return prefs.get(MODEL_DIR, null);
 	}
-	
+
 	public static void setModelDir(String dir)
-	{		
+	{
 		Preferences prefs = getPreferences();
 		prefs.put(MODEL_DIR, dir);
-	}		
+	}
 
 	public static String getJSONDir()
 	{
 		Preferences prefs = getPreferences();
 		return prefs.get(JSON_DIR, null);
 	}
-	
+
 	public static void setJSONDir(String dir)
-	{		
+	{
 		Preferences prefs = getPreferences();
 		prefs.put(JSON_DIR, dir);
-	}		
-	
+	}
+
+	public static boolean getTransparencyMode()
+	{
+		Preferences prefs = getPreferences();
+		return prefs.get(TRANSPARENCY_MODE, "0").equals("1");
+	}
+
+	public static void setTransparencyMode(boolean value)
+	{
+		Preferences prefs = getPreferences();
+		prefs.put(TRANSPARENCY_MODE, value ? "1" : "0");
+	}
+
 	private static Preferences getPreferences()
 	{
 		return Preferences.userNodeForPackage(Settings.class);


### PR DESCRIPTION
Hello again MrCrayFish!
This is a change of the "transparency mode" feature.
With this change, transparency mode is still having its warning message when you enable it but will also present a message when the mode is turned off. The setting is still in the menu, but with a checkbox, so the user can see whether it is enabled or not (if it is not obvious in other ways). The setting will be stored in the user preferenses so it is remembered the next time the application is run.