### PR TITLE
Add support for __comment to be used as the name.

### DIFF
--- a/src/com/mrcrayfish/modelcreator/Importer.java
+++ b/src/com/mrcrayfish/modelcreator/Importer.java
@@ -196,6 +196,10 @@ public class Importer
 		{
 			name = obj.get("comment").getAsString();
 		}
+		else if (obj.has("__comment") && obj.get("__comment").isJsonPrimitive())
+		{
+			name = obj.get("__comment").getAsString();
+		}
 		if (obj.has("from") && obj.get("from").isJsonArray())
 		{
 			from = obj.get("from").getAsJsonArray();


### PR DESCRIPTION
Close #119.

Honestly, it's mostly because the Perl script that lfja wrote to convert ModelBase classes to JSON uses __comment to define the element name.
