### PR TITLE
Fixed ExporterJavaCode having incorrect values and class name

### DIFF
--- a/src/main/java/com/mrcrayfish/modelcreator/ExporterJavaCode.java
+++ b/src/main/java/com/mrcrayfish/modelcreator/ExporterJavaCode.java
@@ -94,7 +94,7 @@ public class ExporterJavaCode extends Exporter
                         double y = element.getStartY();
                         double z = element.getStartZ();
                         writer.write("    ");
-                        writeField(writer, null, name, x, y, z, x + element.getWidth(), y + element.getHeight(), z + element.getDepth());
+                        writeField(writer, null, name, x * 16.0, y * 16.0, z * 16.0, (x + element.getWidth()) * 16.0, (y + element.getHeight()) * 16.0, (z + element.getDepth()) * 16.0);
                     }
                     else
                     {
@@ -139,7 +139,7 @@ public class ExporterJavaCode extends Exporter
                         double y = element.getStartY();
                         double z = element.getStartZ();
                         writer.write("    ");
-                        writeField(writer, null, name, x, y, z, x + element.getWidth(), y + element.getHeight(), z + element.getDepth());
+                        writeField(writer, null, name, x * 16.0, y * 16.0, z * 16.0, (x + element.getWidth()) * 16.0, (y + element.getHeight()) * 16.0, (z + element.getDepth()) * 16.0);
                     }
                     else
                     {

--- a/src/main/java/com/mrcrayfish/modelcreator/ExporterJavaCode.java
+++ b/src/main/java/com/mrcrayfish/modelcreator/ExporterJavaCode.java
@@ -155,10 +155,10 @@ public class ExporterJavaCode extends Exporter
                 else
                 {
                     writer.newLine();
-                    writeNewLine(writer, "    VoxelShape result = ShapeUtils.empty();");
+                    writeNewLine(writer, "    VoxelShape result = VoxelShapes.empty();");
                     writeNewLine(writer, "    for(VoxelShape shape : shapes)");
                     writeNewLine(writer, "    {");
-                    writeNewLine(writer, "        result = ShapeUtils.combine(result, shape, IBooleanFunction.OR);");
+                    writeNewLine(writer, "        result = VoxelShapes.combine(result, shape, IBooleanFunction.OR);");
                     writeNewLine(writer, "    }");
                     writeNewLine(writer, "    return result.simplify();");
                 }


### PR DESCRIPTION
ExporterJavaCode was giving the Block.makeCuboidShape incorrect values, since they should be multiplied with 16, because Block.makeCuboidShape divides all values by 16 internally.

ShapeUtils is called VoxelShapes in forge 1.13.

Fixes #161 